### PR TITLE
Check if another plugin cancelled the BlockBreakEvent before dropping another shulker box.

### DIFF
--- a/spigot/src/main/java/de/sean/blockprot/bukkit/listeners/BlockEventListener.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/listeners/BlockEventListener.java
@@ -108,6 +108,9 @@ public class BlockEventListener implements Listener {
             nbtItem.getOrCreateCompound("BlockEntityTag").getOrCreateCompound("PublicBukkitValues").mergeCompound(nbtTile);
 
             event.getPlayer().getWorld().dropItemNaturally(event.getBlock().getLocation(), item);
+
+            event.getBlock().setType(Material.AIR);
+            event.setCancelled(true); // So that other plugins don't fiddle with this.
         }
     }
 


### PR DESCRIPTION
Fixes #74.

This should fix incompatibilities with other plugins, specifically GriefPrevention, so that shulker box duping does not work anymore. Still checking if this actually fixes this issue.

Please see the below build:
[blockprot-spigot-0.4.12-shulker-dupe-fix-all.zip](https://github.com/spnda/BlockProt/files/7027746/blockprot-spigot-0.4.12-shulker-dupe-fix-all.zip)
