### PR TITLE
Rewrite: Full `BlockAccessMenuEvent` API rewrite

### DIFF
--- a/spigot/src/main/java/de/sean/blockprot/bukkit/events/BlockAccessMenuEvent.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/events/BlockAccessMenuEvent.java
@@ -23,29 +23,33 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Called when a player is trying to access a blocks lock menu.
  * Can be cancelled to prevent the inventory from opening up.
  *
  * @since 0.4.0
  */
-public final class BlockAccessEditMenuEvent extends BaseBlockEvent implements Cancellable {
+public final class BlockAccessMenuEvent extends BaseBlockEvent implements Cancellable {
     @NotNull
     private final Player player;
 
-    private boolean isCancelled = false;
-
     @NotNull
-    private MenuAccess access = MenuAccess.NORMAL;
+    private final Set<MenuPermission> permissions = new HashSet<>();
+
+    private boolean isCancelled = false;
 
     /**
      * @param block  The block that was placed.
      * @param player The player that placed the block.
-     * @see BlockAccessEditMenuEvent
+     * @see BlockAccessMenuEvent
      * @since 0.4.0
      */
-    public BlockAccessEditMenuEvent(@NotNull final Block block,
-                                    @NotNull final Player player) {
+    public BlockAccessMenuEvent(@NotNull final Block block,
+                                @NotNull final Player player) {
         super(block);
         this.player = player;
     }
@@ -62,27 +66,41 @@ public final class BlockAccessEditMenuEvent extends BaseBlockEvent implements Ca
     }
 
     /**
-     * Get the current level of {@link MenuAccess}.
-     *
-     * @return The current access level.
-     * @since 0.4.0
+     * Get the permissions the player has when opening the
+     * menu.
      */
     @NotNull
-    public MenuAccess getAccess() {
-        return access;
+    public Set<MenuPermission> getPermissions() {
+        return permissions;
     }
 
     /**
-     * Sets new permissions. If {@code access} is lower than
-     * the previous permissions, this call will be ignored.
+     * Adds a new permission. See {@link java.util.Collection#add(Object)}
+     * for details on any exceptions and the implementation detail.
      *
-     * @param access The new permissions.
-     * @since 0.4.0
+     * @param permission The new permissions.
      */
-    public void setAccess(@NotNull MenuAccess access) {
-        if (access.ordinal() > this.access.ordinal()) {
-            this.access = access;
-        }
+    public void addPermission(@NotNull MenuPermission permission) {
+        this.permissions.add(permission);
+    }
+
+    /**
+     * Adds multiple permissions to this event.
+     *
+     * @param permissions The permissions do add.
+     */
+    public void addPermissions(@NotNull MenuPermission... permissions) {
+        this.permissions.addAll(Arrays.asList(permissions));
+    }
+
+    /**
+     * Removes a permission. See {@link java.util.Collection#add(Object)}
+     * for details on any exceptions and the implementation detail.
+     *
+     * @param permission The permission to remove.
+     */
+    public void removePermission(@NotNull MenuPermission permission) {
+        this.permissions.remove(permission);
     }
 
     /**
@@ -104,14 +122,16 @@ public final class BlockAccessEditMenuEvent extends BaseBlockEvent implements Ca
     }
 
     /**
-     * The level of access that a player can have.
-     *
-     * @since 0.4.0
+     * The permissions of a player towards the menu. Each one
+     * is specific to one field and one does not imply another
+     * unless explicitly stated.
      */
-    public enum MenuAccess {
-        NONE,
+    public enum MenuPermission {
+        /* Allows a player to see the information of a block */
         INFO,
-        NORMAL,
-        ADMIN
+        /* Allows a player to lock or unlock a block */
+        LOCK,
+        /* Allows a player to manage redstone settings and friends */
+        MANAGER
     }
 }

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/events/BlockAccessMenuEvent.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/events/BlockAccessMenuEvent.java
@@ -118,9 +118,10 @@ public final class BlockAccessMenuEvent extends BaseBlockEvent implements Cancel
     }
 
     /**
-     * The permissions of a player towards the menu. Each one
-     * is specific to one field and one does not imply another
-     * unless explicitly stated.
+     * The different permissions a player can have when opening
+     * the menu. Each permission is specific to one element of the
+     * menus and permission does not imply another unless explicitly
+     * stated.
      */
     public enum MenuPermission {
         /* Allows a player to see the information of a block */

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/events/BlockAccessMenuEvent.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/events/BlockAccessMenuEvent.java
@@ -30,8 +30,6 @@ import java.util.Set;
 /**
  * Called when a player is trying to access a blocks lock menu.
  * Can be cancelled to prevent the inventory from opening up.
- *
- * @since 0.4.0
  */
 public final class BlockAccessMenuEvent extends BaseBlockEvent implements Cancellable {
     @NotNull
@@ -46,7 +44,6 @@ public final class BlockAccessMenuEvent extends BaseBlockEvent implements Cancel
      * @param block  The block that was placed.
      * @param player The player that placed the block.
      * @see BlockAccessMenuEvent
-     * @since 0.4.0
      */
     public BlockAccessMenuEvent(@NotNull final Block block,
                                 @NotNull final Player player) {
@@ -58,7 +55,6 @@ public final class BlockAccessMenuEvent extends BaseBlockEvent implements Cancel
      * The player that is trying to access the edit menu.
      *
      * @return The Bukkit player.
-     * @since 0.4.0
      */
     @NotNull
     public Player getPlayer() {

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/integrations/TownyIntegration.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/integrations/TownyIntegration.java
@@ -27,8 +27,8 @@ import com.palmergames.bukkit.towny.event.town.TownUnclaimEvent;
 import com.palmergames.bukkit.towny.object.*;
 import com.palmergames.bukkit.towny.utils.PlayerCacheUtil;
 import de.sean.blockprot.bukkit.BlockProt;
-import de.sean.blockprot.bukkit.events.BlockAccessEditMenuEvent;
 import de.sean.blockprot.bukkit.events.BlockAccessEvent;
+import de.sean.blockprot.bukkit.events.BlockAccessMenuEvent;
 import de.sean.blockprot.bukkit.events.BlockLockOnPlaceEvent;
 import de.sean.blockprot.bukkit.nbt.BlockNBTHandler;
 import org.bukkit.OfflinePlayer;
@@ -234,7 +234,7 @@ public final class TownyIntegration extends PluginIntegration implements Listene
 
     @EventHandler
     public void onAccessEditMenu(
-        @NotNull final BlockAccessEditMenuEvent event) {
+        @NotNull final BlockAccessMenuEvent event) {
         if (towny == null) {
             return;
         }
@@ -262,7 +262,7 @@ public final class TownyIntegration extends PluginIntegration implements Listene
 
         if (residentEqualsPlayer(town.getMayor(), event.getPlayer())
             && shouldAllowMayorToSeeBlockInfo()) {
-            event.setAccess(BlockAccessEditMenuEvent.MenuAccess.INFO);
+            event.addPermission(BlockAccessMenuEvent.MenuPermission.INFO);
         } else if (town.isRuined()) {
             // Cancel the event if we don't want to bypass protections
             // in ruined towns.

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/BlockLockInventory.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/BlockLockInventory.java
@@ -23,7 +23,6 @@ import de.sean.blockprot.bukkit.TranslationKey;
 import de.sean.blockprot.bukkit.Translator;
 import de.sean.blockprot.bukkit.events.BlockAccessMenuEvent;
 import de.sean.blockprot.bukkit.nbt.BlockNBTHandler;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -100,7 +99,6 @@ public class BlockLockInventory extends BlockProtInventory {
 
         String owner = handler.getOwner();
 
-        Bukkit.getLogger().info(state.menuPermissions.toString());
         if (state.menuPermissions.contains(BlockAccessMenuEvent.MenuPermission.LOCK)) {
             setItemStack(
                 0,

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/BlockLockInventory.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/BlockLockInventory.java
@@ -21,8 +21,9 @@ package de.sean.blockprot.bukkit.inventories;
 import de.sean.blockprot.bukkit.BlockProt;
 import de.sean.blockprot.bukkit.TranslationKey;
 import de.sean.blockprot.bukkit.Translator;
-import de.sean.blockprot.bukkit.events.BlockAccessEditMenuEvent;
+import de.sean.blockprot.bukkit.events.BlockAccessMenuEvent;
 import de.sean.blockprot.bukkit.nbt.BlockNBTHandler;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -97,24 +98,20 @@ public class BlockLockInventory extends BlockProtInventory {
         final InventoryState state = InventoryState.get(player.getUniqueId());
         if (state == null) return inventory;
 
-        String playerUuid = player.getUniqueId().toString();
         String owner = handler.getOwner();
 
-        if (owner.isEmpty()) {
+        Bukkit.getLogger().info(state.menuPermissions.toString());
+        if (state.menuPermissions.contains(BlockAccessMenuEvent.MenuPermission.LOCK)) {
             setItemStack(
                 0,
                 getProperMaterial(material),
-                TranslationKey.INVENTORIES__LOCK
-            );
-        } else if (owner.equals(playerUuid) || state.menuAccess == BlockAccessEditMenuEvent.MenuAccess.ADMIN) {
-            setItemStack(
-                0,
-                getProperMaterial(material),
-                TranslationKey.INVENTORIES__UNLOCK
+                owner.isEmpty()
+                    ? TranslationKey.INVENTORIES__LOCK
+                    : TranslationKey.INVENTORIES__UNLOCK
             );
         }
 
-        if (owner.equals(playerUuid) && state.menuAccess.ordinal() >= BlockAccessEditMenuEvent.MenuAccess.NORMAL.ordinal()) {
+        if (state.menuPermissions.contains(BlockAccessMenuEvent.MenuPermission.MANAGER)) {
             setItemStack(
                 1,
                 Material.REDSTONE,
@@ -127,9 +124,7 @@ public class BlockLockInventory extends BlockProtInventory {
             );
         }
 
-        if (!owner.isEmpty() &&
-            state.menuAccess.ordinal() >= BlockAccessEditMenuEvent.MenuAccess.INFO.ordinal()
-        ) {
+        if (!owner.isEmpty() && state.menuPermissions.contains(BlockAccessMenuEvent.MenuPermission.INFO)) {
             setItemStack(
                 InventoryConstants.lineLength - 2,
                 Material.OAK_SIGN,

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/InventoryState.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/InventoryState.java
@@ -18,15 +18,13 @@
 
 package de.sean.blockprot.bukkit.inventories;
 
-import de.sean.blockprot.bukkit.events.BlockAccessEditMenuEvent;
+import de.sean.blockprot.bukkit.events.BlockAccessMenuEvent;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * Storage for the current state and location of each player's
@@ -87,7 +85,7 @@ public final class InventoryState {
      * @since 0.4.7
      */
     @NotNull
-    public BlockAccessEditMenuEvent.MenuAccess menuAccess = BlockAccessEditMenuEvent.MenuAccess.NONE;
+    public Set<BlockAccessMenuEvent.MenuPermission> menuPermissions = new HashSet<>();
 
     public InventoryState(@Nullable Block block) {
         this.block = block;

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/InventoryState.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/InventoryState.java
@@ -80,9 +80,7 @@ public final class InventoryState {
     public OfflinePlayer currentFriend = null;
 
     /**
-     * The current cached menu access for this state.
-     *
-     * @since 0.4.7
+     * The current cached menu permissions for this player.
      */
     @NotNull
     public Set<BlockAccessMenuEvent.MenuPermission> menuPermissions = new HashSet<>();


### PR DESCRIPTION
Completely redone the `BlockAccessMenuEvent` and the `MenuPermission` enum thereof. As it would be a too big maintainability cost, the old classes are removed without notice.