### PR TITLE
Add: Set permissions on default friends

### DIFF
--- a/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/BlockProtInventory.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/BlockProtInventory.java
@@ -167,15 +167,12 @@ public abstract class BlockProtInventory implements InventoryHolder {
                 action
             ),
             (handler) -> {
-                List<String> currentFriends = handler.getDefaultFriends();
                 switch (action) {
                     case ADD_FRIEND:
-                        currentFriends.add(friend.getUniqueId().toString());
-                        handler.setDefaultFriends(currentFriends);
+                        handler.addFriend(friend.getUniqueId().toString());
                         break;
                     case REMOVE_FRIEND:
-                        currentFriends.remove(friend.getUniqueId().toString());
-                        handler.setDefaultFriends(currentFriends);
+                        handler.removeFriend(friend.getUniqueId().toString());
                         break;
                 }
                 return null;

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/BlockProtInventory.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/BlockProtInventory.java
@@ -22,9 +22,11 @@ import de.sean.blockprot.bukkit.TranslationKey;
 import de.sean.blockprot.bukkit.Translator;
 import de.sean.blockprot.bukkit.nbt.BlockNBTHandler;
 import de.sean.blockprot.bukkit.nbt.FriendHandler;
+import de.sean.blockprot.bukkit.nbt.FriendSupportingHandler;
 import de.sean.blockprot.bukkit.nbt.PlayerSettingsHandler;
 import de.sean.blockprot.nbt.FriendModifyAction;
 import de.sean.blockprot.nbt.LockReturnValue;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
@@ -470,6 +472,21 @@ public abstract class BlockProtInventory implements InventoryHolder {
             return new BlockNBTHandler(block);
         } catch (RuntimeException e) {
             return null;
+        }
+    }
+
+    protected @Nullable FriendSupportingHandler<NBTCompound> getFriendSupportingHandler(@NotNull InventoryState.FriendSearchState state,
+                                                                                        @Nullable Player player,
+                                                                                        @Nullable Block block) {
+        switch (state) {
+            case FRIEND_SEARCH:
+                if (block == null) return null;
+                return getNbtHandlerOrNull(block);
+            case DEFAULT_FRIEND_SEARCH:
+                if (player == null) return null;
+                return new PlayerSettingsHandler(player);
+            default:
+                return null;
         }
     }
 

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/FriendDetailInventory.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/FriendDetailInventory.java
@@ -131,17 +131,8 @@ public final class FriendDetailInventory extends BlockProtInventory {
         setItemStack(
             1, Material.RED_STAINED_GLASS_PANE, TranslationKey.INVENTORIES__FRIENDS__REMOVE);
 
-        @Nullable FriendSupportingHandler<NBTCompound> handler;
-        switch (state.friendSearchState) {
-            case FRIEND_SEARCH:
-                handler = getNbtHandlerOrNull(Objects.requireNonNull(state.getBlock()));
-                break;
-            case DEFAULT_FRIEND_SEARCH:
-                handler = new PlayerSettingsHandler(player);
-                break;
-            default:
-                return null;
-        }
+        final @Nullable FriendSupportingHandler<NBTCompound> handler =
+            getFriendSupportingHandler(state.friendSearchState, player, state.getBlock());
         if (handler == null) return null;
 
         final Optional<FriendHandler> friendHandler =

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/FriendManageInventory.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/FriendManageInventory.java
@@ -39,8 +39,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 public final class FriendManageInventory extends BlockProtInventory {
     private int maxSkulls = getSize() - 5;
@@ -164,18 +162,14 @@ public final class FriendManageInventory extends BlockProtInventory {
                 if (handler == null) return null;
                 // Let the players be filtered by any plugin integration.
                 players = PluginIntegration.filterFriends(
-                    (ArrayList<OfflinePlayer>) mapFriendsToPlayer(handler.getFriendsStream()), player, state.getBlock());
+                    (ArrayList<OfflinePlayer>) handler.getFriendsAsPlayers(), player, state.getBlock());
                 break;
             }
             case DEFAULT_FRIEND_SEARCH: {
                 // We have 1 button less, as that button is only for blocks, which gives us room
                 // for one more friend.
                 maxSkulls += 1;
-                final PlayerSettingsHandler settingsHandler = new PlayerSettingsHandler(player);
-                players = settingsHandler.getDefaultFriends()
-                    .stream()
-                    .map((friend) -> Bukkit.getOfflinePlayer(UUID.fromString(friend)))
-                    .collect(Collectors.toList());
+                players = new PlayerSettingsHandler(player).getFriendsAsPlayers();
                 break;
             }
             default: {

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/FriendManageInventory.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/FriendManageInventory.java
@@ -162,10 +162,6 @@ public final class FriendManageInventory extends BlockProtInventory {
         if (state.friendSearchState == FriendSearchState.FRIEND_SEARCH && state.getBlock() != null) {
             PluginIntegration.filterFriends(
                 (ArrayList<OfflinePlayer>) players, player, state.getBlock());
-        } else if (state.friendSearchState == FriendSearchState.DEFAULT_FRIEND_SEARCH) {
-            // We have 1 button less, as that button is only for blocks, which gives us room
-            // for one more friend.
-            maxSkulls += 1;
         }
 
         // Fill the first page inventory with skeleton skulls.

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/FriendSearchResultInventory.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/FriendSearchResultInventory.java
@@ -30,7 +30,6 @@ import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
@@ -121,20 +120,9 @@ public class FriendSearchResultInventory extends BlockProtInventory {
         List<OfflinePlayer> potentialFriends = Arrays.asList(Bukkit.getOfflinePlayers());
 
         // The already existing friends we want to add to.
-        final FriendSupportingHandler<NBTCompound> handler;
-        switch (state.friendSearchState) {
-            case FRIEND_SEARCH:
-                final Block block = state.getBlock();
-                if (block == null) return null;
-                handler = getNbtHandlerOrNull(block);
-                break;
-            case DEFAULT_FRIEND_SEARCH:
-                handler = new PlayerSettingsHandler(player);
-                break;
-            default:
-                return null;
-        }
-        if (handler == null) return null; // return null to indicate a issue.
+        final @Nullable FriendSupportingHandler<NBTCompound> handler =
+            getFriendSupportingHandler(state.friendSearchState, player, state.getBlock());
+        if (handler == null) return null; // return null to indicate an issue.
 
         // We'll filter all doubled friends out of the list and add them to the current InventoryState.
         potentialFriends = potentialFriends.stream().filter((p) -> {

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/FriendSearchResultInventory.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/FriendSearchResultInventory.java
@@ -137,7 +137,7 @@ public class FriendSearchResultInventory extends BlockProtInventory {
         }).collect(Collectors.toList());
         if (state.friendSearchState == InventoryState.FriendSearchState.FRIEND_SEARCH && state.getBlock() != null) {
             // Allow integrations to additionally filter friends.
-            PluginIntegration.filterFriends((ArrayList<OfflinePlayer>) potentialFriends, player, state.getBlock());
+            potentialFriends = PluginIntegration.filterFriends((ArrayList<OfflinePlayer>) potentialFriends, player, state.getBlock());
         }
         state.friendResultCache.clear();
         state.friendResultCache.addAll(potentialFriends);

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/listeners/BlockEventListener.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/listeners/BlockEventListener.java
@@ -42,7 +42,6 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
-import java.util.List;
 
 public class BlockEventListener implements Listener {
     private final BlockProt blockProt;
@@ -151,10 +150,9 @@ public class BlockEventListener implements Listener {
                 Bukkit.getPluginManager().callEvent(lockOnPlaceEvent);
                 if (!lockOnPlaceEvent.isCancelled()) {
                     handler.lockBlock(event.getPlayer());
-                    List<String> friends = settingsHandler.getDefaultFriends();
-                    for (String friend : friends) {
-                        handler.addFriend(friend);
-                    }
+                    settingsHandler
+                        .getFriendsStream()
+                        .forEach(fh -> handler.addFriend(fh.getName()));
                 }
 
                 if (BlockProt.getDefaultConfig().disallowRedstoneOnPlace()) {
@@ -175,10 +173,9 @@ public class BlockEventListener implements Listener {
                     handler.setOwner(
                         settingsHandler.getLockOnPlace() ? playerUuid : ""
                     );
-                    List<String> friends = settingsHandler.getDefaultFriends();
-                    for (String friend : friends) {
-                        handler.addFriend(friend);
-                    }
+                    settingsHandler
+                        .getFriendsStream()
+                        .forEach(fh -> handler.addFriend(fh.getName()));
                 }
                 if (BlockProt.getDefaultConfig().disallowRedstoneOnPlace()) {
                     handler.getRedstoneHandler().setAll(false);

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/listeners/BlockEventListener.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/listeners/BlockEventListener.java
@@ -152,7 +152,7 @@ public class BlockEventListener implements Listener {
                     handler.lockBlock(event.getPlayer());
                     settingsHandler
                         .getFriendsStream()
-                        .forEach(fh -> handler.addFriend(fh.getName()));
+                        .forEach(handler::addFriend);
                 }
 
                 if (BlockProt.getDefaultConfig().disallowRedstoneOnPlace()) {
@@ -175,7 +175,7 @@ public class BlockEventListener implements Listener {
                     );
                     settingsHandler
                         .getFriendsStream()
-                        .forEach(fh -> handler.addFriend(fh.getName()));
+                        .forEach(handler::addFriend);
                 }
                 if (BlockProt.getDefaultConfig().disallowRedstoneOnPlace()) {
                     handler.getRedstoneHandler().setAll(false);

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/nbt/BlockNBTHandler.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/nbt/BlockNBTHandler.java
@@ -111,10 +111,8 @@ public final class BlockNBTHandler extends FriendSupportingHandler<NBTCompound> 
     /**
      * As of 0.3.0 we expect a list of compounds, in which we can
      * store the access flags and other future settings.
-     * Therefore we will remap the values here. This will possibly
+     * Therefore, we will remap the values here. This will possibly
      * be removed in a future version.
-     *
-     * @since 0.3.0
      */
     @Override
     protected void preFriendReadCallback() {

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/nbt/FriendSupportingHandler.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/nbt/FriendSupportingHandler.java
@@ -121,6 +121,14 @@ public abstract class FriendSupportingHandler<T extends NBTCompound> extends NBT
     }
 
     /**
+     * Adds a new {@link FriendHandler} to this NBT data.
+     */
+    public void addFriend(@NotNull final FriendHandler friend) {
+        NBTCompound compound = container.getOrCreateCompound(friendNbtKey);
+        compound.addCompound(friend.getName()).mergeCompound(friend.container);
+    }
+
+    /**
      * Removes a friend from the NBT.
      *
      * @param friend The friend to remove.

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/nbt/FriendSupportingHandler.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/nbt/FriendSupportingHandler.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2021 spnda
+ * This file is part of BlockProt <https://github.com/spnda/BlockProt>.
+ *
+ * BlockProt is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BlockProt is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BlockProt.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.sean.blockprot.bukkit.nbt;
+
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public abstract class FriendSupportingHandler<T extends NBTCompound> extends NBTHandler<T> {
+    private final @NotNull String friendNbtKey;
+    
+    public FriendSupportingHandler(@NotNull String friendNbtKey) {
+        this.friendNbtKey = friendNbtKey;
+    }
+
+    /**
+     * A function called before friends are read from this NBT compound.
+     * Useful for remapping old data to this new structure.
+     */
+    protected void preFriendReadCallback() {
+
+    }
+
+    /**
+     * Gets a {@link Stream} of {@link FriendHandler} for this block.
+     *
+     * @return A stream of friend handlers for all NBT compounds under
+     * the friend key.
+     */
+    public Stream<FriendHandler> getFriendsStream() {
+        preFriendReadCallback();
+        if (!this.container.hasKey(friendNbtKey)) return Stream.empty();
+
+        final NBTCompound compound = this.container.getOrCreateCompound(friendNbtKey);
+        return compound
+            .getKeys()
+            .stream()
+            .map((k) -> new FriendHandler(compound.getCompound(k)));
+    }
+
+    /**
+     * Gets a {@link List} of friends for this block.
+     *
+     * @return A list of {@link FriendHandler} to read
+     * additional data for each friend.
+     */
+    public List<FriendHandler> getFriends() {
+        return this.getFriendsStream().collect(Collectors.toList());
+    }
+
+    /**
+     * Gets friends as a list of {@link OfflinePlayer}.
+     */
+    public List<OfflinePlayer> getFriendsAsPlayers() {
+        return this.getFriendsStream()
+            .map(f -> Bukkit.getOfflinePlayer(UUID.fromString(f.getName())))
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Set a new list of FriendHandler for the friends list.
+     *
+     * @param access The new list of friends to use.
+     */
+    public void setFriends(@NotNull final List<FriendHandler> access) {
+        container.removeKey(friendNbtKey);
+        if (!access.isEmpty()) {
+            NBTCompound compound = container.addCompound(friendNbtKey);
+            for (FriendHandler handler : access) {
+                NBTCompound newCompound = compound.addCompound(handler.getName());
+                newCompound.mergeCompound(handler.container);
+            }
+        }
+    }
+
+    /**
+     * Filters the results of {@link #getFriends()} for any entry which
+     * id qualifies for {@link String#equals(Object)}.
+     *
+     * @param id The String ID to check for. Usually a UUID as a String as {@link UUID#toString()}.
+     * @return The first {@link FriendHandler} found, or none.
+     */
+    @NotNull
+    public Optional<FriendHandler> getFriend(@NotNull final String id) {
+        return getFriendsStream()
+            .filter((f) -> f.getName().equals(id))
+            .findFirst();
+    }
+
+    /**
+     * Adds a new friend to the NBT.
+     *
+     * @param friend The friend to add.
+     */
+    public void addFriend(@NotNull final String friend) {
+        NBTCompound compound = container.getOrCreateCompound(friendNbtKey);
+        compound.addCompound(friend).setString("id", friend);
+    }
+
+    /**
+     * Removes a friend from the NBT.
+     *
+     * @param friend The friend to remove.
+     */
+    public void removeFriend(@NotNull final String friend) {
+        NBTCompound compound = container.getOrCreateCompound(friendNbtKey);
+        compound.removeKey(friend);
+    }
+
+    /**
+     * Checks whether this blocks friends contain given {@code friendUuid}.
+     * @see #containsFriend(Stream, String) 
+     */
+    public boolean containsFriend(@NotNull final String friendUuid) {
+        return containsFriend(getFriendsStream(), friendUuid);
+    }
+
+    /**
+     * Checks whether {@code friends} contains {@code friend}.
+     *
+     * @param friends A list of all friends we want to filter.
+     * @param friendUuid The UUID of a player we want to check for.
+     * @return True, if the list does contain that friend.
+     */
+    public boolean containsFriend(@NotNull final Stream<FriendHandler> friends, @NotNull final String friendUuid) {
+        return friends
+            .anyMatch((f) -> f.getName().equals(friendUuid));
+    }
+}

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/nbt/FriendSupportingHandler.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/nbt/FriendSupportingHandler.java
@@ -62,10 +62,7 @@ public abstract class FriendSupportingHandler<T extends NBTCompound> extends NBT
     }
 
     /**
-     * Gets a {@link List} of friends for this block.
-     *
-     * @return A list of {@link FriendHandler} to read
-     * additional data for each friend.
+     * Gets a {@link List} of {@link FriendHandler} for this block.
      */
     public List<FriendHandler> getFriends() {
         return this.getFriendsStream().collect(Collectors.toList());
@@ -82,25 +79,17 @@ public abstract class FriendSupportingHandler<T extends NBTCompound> extends NBT
 
     /**
      * Set a new list of FriendHandler for the friends list.
-     *
-     * @param access The new list of friends to use.
      */
-    public void setFriends(@NotNull final List<FriendHandler> access) {
+    public void setFriends(@NotNull final List<FriendHandler> friends) {
         container.removeKey(friendNbtKey);
-        if (!access.isEmpty()) {
-            NBTCompound compound = container.addCompound(friendNbtKey);
-            for (FriendHandler handler : access) {
-                NBTCompound newCompound = compound.addCompound(handler.getName());
-                newCompound.mergeCompound(handler.container);
-            }
-        }
+        friends.forEach(this::addFriend);
     }
 
     /**
-     * Filters the results of {@link #getFriends()} for any entry which
-     * id qualifies for {@link String#equals(Object)}.
+     * Filters the results of {@link #getFriends()} for any entry whose
+     * UUID qualifies for {@link String#equals(Object)} with given {@code id}.
      *
-     * @param id The String ID to check for. Usually a UUID as a String as {@link UUID#toString()}.
+     * @param id The UUID to check for.
      * @return The first {@link FriendHandler} found, or none.
      */
     @NotNull
@@ -112,8 +101,6 @@ public abstract class FriendSupportingHandler<T extends NBTCompound> extends NBT
 
     /**
      * Adds a new friend to the NBT.
-     *
-     * @param friend The friend to add.
      */
     public void addFriend(@NotNull final String friend) {
         NBTCompound compound = container.getOrCreateCompound(friendNbtKey);
@@ -130,8 +117,6 @@ public abstract class FriendSupportingHandler<T extends NBTCompound> extends NBT
 
     /**
      * Removes a friend from the NBT.
-     *
-     * @param friend The friend to remove.
      */
     public void removeFriend(@NotNull final String friend) {
         NBTCompound compound = container.getOrCreateCompound(friendNbtKey);

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/nbt/PlayerSettingsHandler.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/nbt/PlayerSettingsHandler.java
@@ -144,6 +144,21 @@ public final class PlayerSettingsHandler extends FriendSupportingHandler<NBTComp
     }
 
     /**
+     * Set a new list of default friends. These have to be UUID-based,
+     * otherwise other callers using {@link #getDefaultFriends()} will
+     * experience issues. This does not get checked.
+     *
+     * @param friends A list of UUIDs representing a list of friends.
+     * @since 0.2.3
+     * @deprecated Use {@link #setFriends(List)} instead.
+     */
+    @Deprecated
+    public void setDefaultFriends(@NotNull final List<String> friends) {
+        container.removeKey(DEFAULT_FRIENDS_ATTRIBUTE);
+        friends.forEach(this::addFriend);
+    }
+
+    /**
      * Get the current search history for this player.
      * 
      * @return A list of UUIDs for each player this player has

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/nbt/PlayerSettingsHandler.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/nbt/PlayerSettingsHandler.java
@@ -130,20 +130,6 @@ public final class PlayerSettingsHandler extends FriendSupportingHandler<NBTComp
     }
 
     /**
-     * Gets the default friends as a list of {@link OfflinePlayer}. Uses
-     * {@link #getDefaultFriends} as a base.
-     *
-     * @return All default friends as a list of {@link OfflinePlayer}.
-     * @since 0.2.3
-     * @deprecated Use {@link #getFriendsAsPlayers()} instead.
-     */
-    @Deprecated
-    @NotNull
-    public List<OfflinePlayer> getDefaultFriendsAsPlayers() {
-        return this.getFriendsAsPlayers();
-    }
-
-    /**
      * Set a new list of default friends. These have to be UUID-based,
      * otherwise other callers using {@link #getDefaultFriends()} will
      * experience issues. This does not get checked.
@@ -156,6 +142,20 @@ public final class PlayerSettingsHandler extends FriendSupportingHandler<NBTComp
     public void setDefaultFriends(@NotNull final List<String> friends) {
         container.removeKey(DEFAULT_FRIENDS_ATTRIBUTE);
         friends.forEach(this::addFriend);
+    }
+
+    /**
+     * Gets the default friends as a list of {@link OfflinePlayer}. Uses
+     * {@link #getDefaultFriends} as a base.
+     *
+     * @return All default friends as a list of {@link OfflinePlayer}.
+     * @since 0.2.3
+     * @deprecated Use {@link #getFriendsAsPlayers()} instead.
+     */
+    @Deprecated
+    @NotNull
+    public List<OfflinePlayer> getDefaultFriendsAsPlayers() {
+        return this.getFriendsAsPlayers();
     }
 
     /**

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/nbt/PlayerSettingsHandler.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/nbt/PlayerSettingsHandler.java
@@ -23,7 +23,7 @@ import de.sean.blockprot.bukkit.inventories.InventoryConstants;
 import de.sean.blockprot.util.BlockProtUtil;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NBTEntity;
-import org.bukkit.Bukkit;
+import de.tr7zw.changeme.nbtapi.NBTType;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
  *
  * @since 0.2.3
  */
-public final class PlayerSettingsHandler extends NBTHandler<NBTCompound> {
+public final class PlayerSettingsHandler extends FriendSupportingHandler<NBTCompound> {
     static final String LOCK_ON_PLACE_ATTRIBUTE = "splugin_lock_on_place";
 
     static final String DEFAULT_FRIENDS_ATTRIBUTE = "blockprot_default_friends";
@@ -62,7 +62,7 @@ public final class PlayerSettingsHandler extends NBTHandler<NBTCompound> {
      * @since 0.2.3
      */
     public PlayerSettingsHandler(@NotNull final Player player) {
-        super();
+        super(DEFAULT_FRIENDS_ATTRIBUTE);
         this.player = player;
 
         this.container = new NBTEntity(player).getPersistentDataContainer();
@@ -96,31 +96,37 @@ public final class PlayerSettingsHandler extends NBTHandler<NBTCompound> {
     }
 
     /**
+     * We are switching to a similar system that {@link BlockNBTHandler}
+     * uses. To retain compatibility and upgradability with older versions
+     * we will try to remap the previous data to the new data structure.
+     */
+    @Override
+    protected void preFriendReadCallback() {
+        if (container.hasKey(DEFAULT_FRIENDS_ATTRIBUTE)
+            && container.getType(DEFAULT_FRIENDS_ATTRIBUTE) == NBTType.NBTTagString) {
+            final List<String> originalList = BlockProtUtil
+                .parseStringList(container.getString(DEFAULT_FRIENDS_ATTRIBUTE));
+            
+            container.removeKey(DEFAULT_FRIENDS_ATTRIBUTE); // We have to remove the string to then add the compound.
+            container.addCompound(DEFAULT_FRIENDS_ATTRIBUTE);
+            originalList.forEach(this::addFriend);
+        }
+    }
+
+    /**
      * Get the {@link List} of default friends for this player.
      *
      * @return A List of Player {@link UUID}s as {@link String}s
      * representing each friend.
      * @since 0.2.3
+     * @deprecated Use {@link #getFriends()} instead.
      */
+    @Deprecated
     @NotNull
     public List<String> getDefaultFriends() {
-        if (!container.hasKey(DEFAULT_FRIENDS_ATTRIBUTE)) return new ArrayList<>();
-        else {
-            return BlockProtUtil
-                .parseStringList(container.getString(DEFAULT_FRIENDS_ATTRIBUTE));
-        }
-    }
-
-    /**
-     * Set a new list of default friends. These have to be UUID-based,
-     * otherwise other callers using {@link #getDefaultFriends()} will
-     * experience issues. This does not get checked.
-     *
-     * @param friends A list of UUIDs representing a list of friends.
-     * @since 0.2.3
-     */
-    public void setDefaultFriends(@NotNull final List<String> friends) {
-        container.setString(DEFAULT_FRIENDS_ATTRIBUTE, friends.toString());
+        return getFriendsStream()
+            .map(FriendHandler::getName)
+            .collect(Collectors.toList());
     }
 
     /**
@@ -129,14 +135,12 @@ public final class PlayerSettingsHandler extends NBTHandler<NBTCompound> {
      *
      * @return All default friends as a list of {@link OfflinePlayer}.
      * @since 0.2.3
+     * @deprecated Use {@link #getFriendsAsPlayers()} instead.
      */
+    @Deprecated
     @NotNull
     public List<OfflinePlayer> getDefaultFriendsAsPlayers() {
-        ArrayList<String> friends = (ArrayList<String>) getDefaultFriends();
-        return friends
-            .stream()
-            .map(s -> Bukkit.getOfflinePlayer(UUID.fromString(s)))
-            .collect(Collectors.toList());
+        return this.getFriendsAsPlayers();
     }
 
     /**


### PR DESCRIPTION
Allows any player to set permissions for default friends. This is allowed due to moving the friend functionality from `BlockNBTHandler` into a superclass, `FriendSupportingHandler`. `PlayerSettingsHandler` also inherits that class now to allow for this new functionality.