### PR TITLE
adding per permission max_lock

### DIFF
--- a/spigot/src/main/java/de/sean/blockprot/bukkit/nbt/BlockNBTHandler.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/nbt/BlockNBTHandler.java
@@ -217,13 +217,12 @@ public final class BlockNBTHandler extends FriendSupportingHandler<NBTCompound> 
                             String foundValue = permission.getPermission().toLowerCase().replace("blockprot.locklimit.", "");
                             if (isNotNumeric(foundValue)) continue;
                             if (playerBlocksStatistic.get().size() >= Integer.parseInt(foundValue) ){
-                                return new LockReturnValue(false, LockReturnValue.Reason.NO_PERMISSION);
+                                return new LockReturnValue(false, LockReturnValue.Reason.EXCEEDED_MAX_BLOCK_COUNT);
                             }
                         }
                     }
-                }else
-                if (playerBlocksStatistic.get().size() >= maxBlockCount) {
-                    return new LockReturnValue(false, LockReturnValue.Reason.NO_PERMISSION);
+                }else if (playerBlocksStatistic.get().size() >= maxBlockCount) {
+                    return new LockReturnValue(false, LockReturnValue.Reason.EXCEEDED_MAX_BLOCK_COUNT);
                 }
             }
 

--- a/spigot/src/main/resources/plugin.yml
+++ b/spigot/src/main/resources/plugin.yml
@@ -19,6 +19,12 @@ permissions:
   blockprot.bypass:
     default: false
     description: Allows a player to bypass any protection, effectively having access to every block.
+  blockprot.lockmax:
+    default: false
+    description: Removes or overrides the restriction from player_max_locked_block_count, only if it is set. To override, use blockprot.locklimit.<number>.
+  blockprot.locklimit.<number>:
+    default: false
+    description: Sets a per-player block lock limit. e.g. blockprot.locklimit.50
 commands:
   blockprot:
     description: The main blockprot command


### PR DESCRIPTION
i was wondering to add per player limit or per group limit so i make it this way
if no one have permission the default value will get used from the config.
if a player have a `blockprot.lockmax` permission will have unlimited Max_lock, its mean `blockprot.lockmax` = -1
like give `blockprot.lockmax` to donateros for unlimited lockable chest
if you give some one `blockprot.lockmax` & `blockprot.locklimit.<number>` will have the #number Max_lock