### PR TITLE
Update RedstoneSettingsInventory.java

### DIFF
--- a/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/RedstoneSettingsInventory.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/inventories/RedstoneSettingsInventory.java
@@ -137,13 +137,13 @@ public class RedstoneSettingsInventory extends BlockProtInventory {
             1,
             Material.HOPPER,
             TranslationKey.INVENTORIES__REDSTONE__HOPPER_PROTECTION,
-            pistonProtection
+            hopperProtection
         );
         setEnchantedOptionItemStack(
             2,
             Material.PISTON,
             TranslationKey.INVENTORIES__REDSTONE__PISTON_PROTECTION,
-            hopperProtection
+            pistonProtection
         );
 
         setItemStack(


### PR DESCRIPTION
The variable in creating an item in the inventory in the redstone settings menu was mixed up between, and therefore the switch always showed that the protection was enabled even if it was not enabled. (
Before: https://cdn.discordapp.com/attachments/1051117976402796614/1165380446008389692/Base_Profile_2023.10.21_-_20.59.17.03.mp4
After: https://cdn.discordapp.com/attachments/1051117976402796614/1165380450286579773/Base_Profile_2023.10.21_-_22.52.03.04.mp4

*I even started writing conditions from the beginning to check the protection status and individual creations of an item with and without enchantment, and then I accidentally saw that the variables were mixed up