### PR TITLE
Fix wither explosions breaking protected blocks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,5 @@ blockProtVersion=1.2.3
 nbtApiVersion=2.14.0
 anvilGuiVersion=1.10.3-SNAPSHOT
 townyVersion=0.98.1.6
-papiVersion=2.11.0
+papiVersion=2.11.6
 worldGuardVersion=7.0.7

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/listeners/EntityEventListener.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/listeners/EntityEventListener.java
@@ -20,7 +20,6 @@ package de.sean.blockprot.bukkit.listeners;
 
 import de.sean.blockprot.bukkit.BlockProt;
 import de.sean.blockprot.bukkit.nbt.BlockNBTHandler;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.FallingBlock;

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/listeners/EntityEventListener.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/listeners/EntityEventListener.java
@@ -20,6 +20,7 @@ package de.sean.blockprot.bukkit.listeners;
 
 import de.sean.blockprot.bukkit.BlockProt;
 import de.sean.blockprot.bukkit.nbt.BlockNBTHandler;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.FallingBlock;
@@ -43,6 +44,11 @@ public final class EntityEventListener implements Listener {
                 if (handler.isProtected())
                     event.setCancelled(true);
             }
+        }
+        else if (BlockProt.getDefaultConfig().isLockable(event.getBlock().getType())) {
+            BlockNBTHandler handler = new BlockNBTHandler(event.getBlock());
+            if (handler.isProtected())
+                event.setCancelled(true);
         }
     }
 }


### PR DESCRIPTION
Prevent wither explosions from breaking locked blocks (Also bumps PlaceholderAPI version because plugin won't compile otherwise)