### PR TITLE
Add toggle for simplified hopper logic

### DIFF
--- a/spigot/src/main/java/de/sean/blockprot/bukkit/config/DefaultConfig.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/config/DefaultConfig.java
@@ -88,6 +88,8 @@ public final class DefaultConfig extends BlockProtConfig {
 
     private final List<String> excludedWorlds;
 
+    private final boolean simpleHopperProtection;
+
     /**
      * Create a new default configuration from given {@code config}.
      *
@@ -98,6 +100,7 @@ public final class DefaultConfig extends BlockProtConfig {
         super(config);
 
         this.excludedWorlds = config.getStringList("excluded_worlds");
+        this.simpleHopperProtection = config.getBoolean("simple_hopper_protection");
         this.removeBlockDefaults();
         this.loadBlocksFromConfig();
     }
@@ -403,5 +406,9 @@ public final class DefaultConfig extends BlockProtConfig {
 
     public boolean isLockableInventory(InventoryType type) {
         return lockableInventories.contains(type);
+    }
+
+    public boolean isSimpleHopperProtection() {
+        return simpleHopperProtection;
     }
 }

--- a/spigot/src/main/java/de/sean/blockprot/bukkit/listeners/HopperEventListener.java
+++ b/spigot/src/main/java/de/sean/blockprot/bukkit/listeners/HopperEventListener.java
@@ -42,6 +42,11 @@ public class HopperEventListener implements Listener {
             if (source != null && BlockProt.getDefaultConfig().isLockable(source.getType())) {
                 BlockNBTHandler sourceHandler = new BlockNBTHandler(source);
                 if (sourceHandler.isProtected()) {
+                    // Check if simple hopper protection is enabled, if so we can skip the rest
+                    if (BlockProt.getDefaultConfig().isSimpleHopperProtection()) {
+                        event.setCancelled(true);
+                        return;
+                    }
                     // The source chest is owned by someone. Check if the hopper block is also owned by
                     // the same player and if so, allow this event to happen, regardless of the hopper
                     // protection.

--- a/spigot/src/main/resources/config.yml
+++ b/spigot/src/main/resources/config.yml
@@ -28,6 +28,13 @@ notify_op_of_updates: false
 # placed block, if the player has lock on place enabled.
 redstone_disallowed_by_default: false
 
+# Toggle simple hopper protection, meaning any protected chest
+# can not be interacted with by any hopper. Should significantly
+# improve performance in some cases.
+# WARNING: Will fully disable hoppers moving items from ANY
+# protected container
+simple_hopper_protection: false
+
 # A list of world names the plugin should not be usable in.
 # The case of each name is ignored.
 # Useful for a mining-only world where a block should not be


### PR DESCRIPTION
The default hopper logic can be incredibly performance heavy especially on servers with large amounts of hoppers (as seen by #306), so this PR implements a toggle for greatly simplified hopper handling, which simply prevents any hopper from pulling items from any protected chest.

In my tests this resulted in a 10-15% performance improvement with a medium sized storage system.