### PR TITLE
Update to 1.21.11

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
-blockProtVersion=1.2.6
-nbtApiVersion=2.15.3
-anvilGuiVersion=1.10.10-SNAPSHOT
+blockProtVersion=1.2.7
+nbtApiVersion=2.15.5
+anvilGuiVersion=1.10.11-SNAPSHOT
 townyVersion=0.98.1.6
 papiVersion=2.11.6
 worldGuardVersion=7.0.7

--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -30,6 +30,11 @@ repositories {
         name = "CodeMC"
         content {
             includeGroup("de.tr7zw")
+        }
+    }
+    maven("https://mvn.wesjd.net/") {
+        name = "WesJD"
+        content {
             includeGroup("net.wesjd")
         }
     }


### PR DESCRIPTION
Bumped the dependencies, added WesJD Maven repository (see [here](https://github.com/WesJD/AnvilGUI/commit/3570d207736738396ec9f98e19681ef7be962173)). I briefly tested it on Paper 1.21.11, seems to work fine.